### PR TITLE
Fix typos in FlipCard CSS comments

### DIFF
--- a/src/components/FlipCard.css
+++ b/src/components/FlipCard.css
@@ -19,7 +19,7 @@ body {
   transition: transform 0.6s;
 }
 
-/*Roatating it 180 degrees*/
+/*Rotating it 180 degrees.*/
 .flipped {
   transform: rotateY(180deg);
 }
@@ -45,7 +45,7 @@ body {
   color: white;
 }
 
-/*Changing the back elment*/
+/*Changing the back element.*/
 .back {
   background-color: white;
   color: black;


### PR DESCRIPTION
## Summary
- fix typos in `FlipCard.css` comments

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840e5e65830832eaed3b9c6aa7518df