### PR TITLE
Fix asset path and update tests

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Add Timer button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByRole('button', { name: /Add Timer/i });
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/src/components/FlipCard.css
+++ b/src/components/FlipCard.css
@@ -40,7 +40,7 @@ body {
 
 /*Changing the front element*/
 .front {
-  background-image: url("C:\Users\marti\OneDrive\Desktop\flipfit\public\imgs\card-back-red.png");
+  background-image: url("/imgs/card-back-red.png");
   background-size: cover;
   color: white;
 }


### PR DESCRIPTION
## Summary
- fix path for card-back-red.png so it loads from `public/imgs`
- update React test to look for "Add Timer" button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840e4cbce54832e8542373fc4d2be54