### PR TITLE
Prevent Add Timer from toggling card

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('Add Timer button is present and does not flip card', () => {
+  const { container } = render(<App />);
+  const card = container.querySelector('.flip-card');
+  const inner = container.querySelector('.flip-card-inner');
+
+  fireEvent.click(card);
+  expect(inner.classList.contains('flipped')).toBe(true);
+
+  const buttonElement = screen.getByRole('button', { name: /Add Timer/i });
+  fireEvent.click(buttonElement);
+  expect(inner.classList.contains('flipped')).toBe(true);
 });

--- a/src/components/FlipCard.css
+++ b/src/components/FlipCard.css
@@ -40,7 +40,7 @@ body {
 
 /*Changing the front element*/
 .front {
-  background-image: url("C:\Users\marti\OneDrive\Desktop\flipfit\public\imgs\card-back-red.png");
+  background-image: url("/imgs/card-back-red.png");
   background-size: cover;
   color: white;
 }

--- a/src/components/FlipCard.js
+++ b/src/components/FlipCard.js
@@ -22,7 +22,12 @@ function FlipCard() {
             <figure>
               <img src="/imgs/pushup-1462808858.gif" alt="pushups-gif" />
             </figure>
-            <input type="button" value="Add Timer" id="timer-button" />
+            <input
+              type="button"
+              value="Add Timer"
+              id="timer-button"
+              onClick={(e) => e.stopPropagation()}
+            />
           </section>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- stop click bubbling on Add Timer button
- test that clicking timer button doesn't flip the card

## Testing
- `npm install`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840e4cbce54832e8542373fc4d2be54