### PR TITLE
Add dynamic workouts, timer, deck, and navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3088,6 +3089,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13924,6 +13934,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,19 @@
 import React from "react";
-import FlipCard from "./components/FlipCard";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import WorkoutDeck from "./components/WorkoutDeck";
+import Progress from "./components/Progress";
 
 function App() {
   return (
-    <div className="App">
-      <FlipCard />
-    </div>
+    <Router>
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/progress">Progress</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<WorkoutDeck />} />
+        <Route path="/progress" element={<Progress />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders Add Timer button', () => {
   render(<App />);
-  const buttonElement = screen.getByRole('button', { name: /Add Timer/i });
-  expect(buttonElement).toBeInTheDocument();
+  const buttons = screen.getAllByRole('button', { name: /Add Timer/i });
+  expect(buttons.length).toBeGreaterThan(0);
 });

--- a/src/components/FlipCard.js
+++ b/src/components/FlipCard.js
@@ -1,11 +1,18 @@
 import React, { useState } from "react";
 import "./FlipCard.css";
+import Timer from "./Timer";
 
-function FlipCard() {
+function FlipCard({ workout, onComplete }) {
   const [isFlipped, setIsFlipped] = useState(false);
+  const [showTimer, setShowTimer] = useState(false);
 
   const handleFlip = () => {
     setIsFlipped(!isFlipped);
+  };
+
+  const handleTimerFinish = () => {
+    setShowTimer(false);
+    onComplete && onComplete(workout.name);
   };
 
   return (
@@ -17,12 +24,25 @@ function FlipCard() {
         <div className="back">
           <section id="workout">
             <p>
-              Push-ups <br />4 X 20
+              {workout.name} <br />
+              {workout.reps}
             </p>
             <figure>
-              <img src="/imgs/pushup-1462808858.gif" alt="pushups-gif" />
+              <img src={workout.image} alt={`${workout.name} gif`} />
             </figure>
-            <input type="button" value="Add Timer" id="timer-button" />
+            {showTimer ? (
+              <Timer seconds={30} onFinish={handleTimerFinish} />
+            ) : (
+              <input
+                type="button"
+                value="Add Timer"
+                id="timer-button"
+                onClick={e => {
+                  e.stopPropagation();
+                  setShowTimer(true);
+                }}
+              />
+            )}
           </section>
         </div>
       </div>

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+function Progress() {
+  const completed = JSON.parse(localStorage.getItem("completed") || "[]");
+  if (completed.length === 0) {
+    return <p>No workouts completed yet.</p>;
+  }
+  return (
+    <div>
+      <h2>Completed Workouts</h2>
+      <ul>
+        {completed.map(name => (
+          <li key={name}>{name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Progress;

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -1,0 +1,18 @@
+import React, { useState, useEffect } from "react";
+
+function Timer({ seconds, onFinish }) {
+  const [timeLeft, setTimeLeft] = useState(seconds);
+
+  useEffect(() => {
+    if (timeLeft <= 0) {
+      onFinish && onFinish();
+      return;
+    }
+    const id = setInterval(() => setTimeLeft(t => t - 1), 1000);
+    return () => clearInterval(id);
+  }, [timeLeft, onFinish]);
+
+  return <div>{timeLeft}s</div>;
+}
+
+export default Timer;

--- a/src/components/WorkoutDeck.js
+++ b/src/components/WorkoutDeck.js
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+import FlipCard from "./FlipCard";
+import workoutsData from "../data/workouts.json";
+
+function WorkoutDeck() {
+  const [completed, setCompleted] = useState(() => {
+    const saved = localStorage.getItem("completed");
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem("completed", JSON.stringify(completed));
+  }, [completed]);
+
+  const handleComplete = name => {
+    if (!completed.includes(name)) {
+      setCompleted([...completed, name]);
+    }
+  };
+
+  return (
+    <div>
+      {workoutsData.map(w => (
+        <FlipCard key={w.name} workout={w} onComplete={handleComplete} />
+      ))}
+    </div>
+  );
+}
+
+export default WorkoutDeck;

--- a/src/data/workouts.json
+++ b/src/data/workouts.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Push-ups",
+    "reps": "4 x 20",
+    "image": "/imgs/pushup-1462808858.gif"
+  },
+  {
+    "name": "Squats",
+    "reps": "3 x 15",
+    "image": "/imgs/pushup-1462808858.gif"
+  },
+  {
+    "name": "Jumping Jacks",
+    "reps": "3 x 30",
+    "image": "/imgs/pushup-1462808858.gif"
+  }
+]


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- implement `FlipCard` with timer and props
- show multiple cards via `WorkoutDeck`
- track completed workouts in localStorage and show via `Progress` component
- use React Router for navigation between Home and Progress
- add simple data file with workout list
- adjust test for multiple Add Timer buttons

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840ebc38914832ea5ed3288bbb60cca